### PR TITLE
replace model by note_type

### DIFF
--- a/src/batch_editing/main.py
+++ b/src/batch_editing/main.py
@@ -131,7 +131,7 @@ class BatchEditDialog(QDialog):
     def _getFields(self):
         nid = self.nids[0]
         mw = self.browser.mw
-        model = mw.col.getNote(nid).model()
+        model = mw.col.getNote(nid).note_type()
         fields = mw.col.models.fieldNames(model)
         return fields
 


### PR DESCRIPTION
This simply ensure less warning in the terminal

Warnings also exists about beginReset, but I'm less clear about what must be done with it

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
